### PR TITLE
Ensure usability on Safari and Firefox.

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -25,12 +25,12 @@
 			[VOTE-CONTROLS]
 		</div>
 		<div class="pdf-container" id="pdf-container">
-			<object id="pdf-viewer" class="pdf-viewer-welcome" data="/dummy" type="application/pdf">
+			<div id="pdf-viewer" class="pdf-viewer-welcome">
 				<div id="pdf-alt" class="pdf-alt">
 					<img width="100%" src="/static/kirb_phones.png" />
 					<h2>Welcome!<br>Select one of the entries on the left to view its score.</h2>
 				</div>
-			</object>
+			</div>
 		</div>
 		<div class="entry-list">
 			[ENTRY-LIST]
@@ -72,12 +72,12 @@
 		function viewPDF(url)
 		{
 			document.getElementById("pdf-container").innerHTML =
-				"<object id='pdf-viewer' class='pdf-viewer-live' data='" + url + "' type='application/pdf'>"
-					"<div id='pdf-alt' class='pdf-alt'>"
-						"<img width='100%' src='/static/kirb_think.png' /><h2><a href='"
-						+ url + "'>Link to PDF (embedded viewer failed)</a></h2>";
-					"</div>"
-				"</object>"
+				`<object id="pdf-viewer" class="pdf-viewer-live" data="${url}" type="application/pdf">
+					<div id="pdf-alt" class="pdf-alt">
+						<img width="100%" src="/static/kirb_think.png">
+						<h2><a href="${url}">Link to PDF (embedded viewer failed)</a></h2>
+					</div>
+				</object>`;
 		}
 	</script>
 </body>

--- a/templates/vote.html
+++ b/templates/vote.html
@@ -15,12 +15,12 @@
 		</div>
 
 		<div class="pdf-container" id="pdf-container">
-			<object id="pdf-viewer" class="pdf-viewer-welcome" data="/dummy" type="application/pdf">
+			<div id="pdf-viewer" class="pdf-viewer-welcome">
 				<div id="pdf-alt" class="pdf-alt">
 					<img width="100%" src="/static/kirb_phones.png" />
 					<h2>Welcome!<br>Select one of the entries on the left to view its score.</h2>
 				</div>
-			</object>
+			</div>
 		</div>
 	</div>
 
@@ -28,12 +28,12 @@
 		function viewPDF(url)
 		{
 			document.getElementById("pdf-container").innerHTML =
-				"<object id='pdf-viewer' class='pdf-viewer-live' data='" + url + "' type='application/pdf'>"
-					"<div id='pdf-alt' class='pdf-alt'>"
-						"<img width='100%' src='/static/kirb_think.png' /><h2><a href='"
-						+ url + "'>Link to PDF (embedded viewer failed)</a></h2>";
-					"</div>"
-				"</object>"
+				`<object id="pdf-viewer" class="pdf-viewer-live" data="${url}" type="application/pdf">
+					<div id="pdf-alt" class="pdf-alt">
+						<img width="100%" src="/static/kirb_think.png">
+						<h2><a href="${url}">Link to PDF (embedded viewer failed)</a></h2>
+					</div>
+				</object>`;
 		}
 	</script>
 </body>


### PR DESCRIPTION
(I think this resolves #22.)

Currently this site only works in Chrome due to a couple of bugs:

1. Loading a non-existent PDF object is evidently not just an error in the console but also causes the page to grind. I did the simplest possible thing and made `.pdf-viewer-welcome` a div (although one could go a step further and just display `div.pdf-alt` directly).

2. `viewPDF()` was attempting to concatenate strings by adjacency alone. (I'm horrified that Chrome accepted this! :scream:) Using template strings instead means we don't need to worry about `+`s at all.

This PR fixes both.

Note: There is one less critical issue that remains—Safari shows the embedded audio elements as "Live Broadcast" because it's failing to determine their length. This seems to be a [well-known issue](https://stackoverflow.com/questions/1995589/html5-audio-safari-live-broadcast-vs-not) and appears to be fixable by having the server send a Content-Range header.