### PR TITLE
myresults updates (& tiny fixes)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,7 +17,7 @@ client = commands.Bot(description="Musical Voting Platform",
                       command_prefix=[],
                       case_insensitive=True,
                       help_command=None)
-config: dict = None
+config = None
 
 
 async def start(_config):

--- a/bot.py
+++ b/bot.py
@@ -435,8 +435,8 @@ async def myresults(context: commands.Context) -> None:
     week = compo.get_week(False)
 
     if week["votingOpen"]:
-        await context.send("You can't really get results while they're still coming"
-                           "in despite what election coverage would lead you to believe, sorry")
+        await context.send("You can't really get results while they're still coming "
+                           "in, despite what election coverage would lead you to believe; sorry.")
         return
 
     user_entry = None

--- a/bot.py
+++ b/bot.py
@@ -395,7 +395,7 @@ async def googleformslist(context: commands.Context) -> None:
 
     response += "\n```"
 
-    await context.channel.send(response)
+    await context.send(response)
 
 
 @client.command()
@@ -406,7 +406,7 @@ async def howmany(context: commands.Context) -> None:
 
     response = "%d, so far." % compo.count_valid_entries(True)
 
-    await context.channel.send(response)
+    await context.send(response)
 
 
 @client.command()

--- a/bot.py
+++ b/bot.py
@@ -433,6 +433,10 @@ async def status(context: commands.Context) -> None:
 async def myresults(context: commands.Context) -> None:
     week = compo.get_week(False)
 
+    if week["votingOpen"]:
+        await context.send("You can't really get results while they're still coming in despite what election coverage would lead you to believe, sorry")
+        return
+
     user_entry = None
     
     # change to list comp or some other search method?

--- a/bot.py
+++ b/bot.py
@@ -426,7 +426,8 @@ async def status(context: commands.Context) -> None:
             await context.send(entry_info_message(entry))
             return
 
-    await context.send("You haven't submitted anything yet! But if you want to you can with %ssubmit !" % config["command_prefix"][0])
+    await context.send("You haven't submitted anything yet! "
+                       "But if you want to you can with %ssubmit !" % config["command_prefix"][0])
 
 @client.command()
 @commands.dm_only()
@@ -434,7 +435,8 @@ async def myresults(context: commands.Context) -> None:
     week = compo.get_week(False)
 
     if week["votingOpen"]:
-        await context.send("You can't really get results while they're still coming in despite what election coverage would lead you to believe, sorry")
+        await context.send("You can't really get results while they're still coming"
+                           "in despite what election coverage would lead you to believe, sorry")
         return
 
     user_entry = None

--- a/bot.py
+++ b/bot.py
@@ -470,6 +470,11 @@ async def myresults(context: commands.Context) -> None:
             score[1] += 1
     
     message = []
+    message.append("Please keep in mind that music is subjective, and that "
+                   "these scores shouldn't be taken to represent the quality of"
+                   " your entry-- your artistic work is valuable, regardless of"
+                   " what results it was awarded, so don't worry too much about it")
+    message.append("And with that out of the way")
     message.append("*drumroll please*")
     for category in results:
         total = results[category][0]

--- a/bot.py
+++ b/bot.py
@@ -474,7 +474,7 @@ async def myresults(context: commands.Context) -> None:
                    "these scores shouldn't be taken to represent the quality of"
                    " your entry-- your artistic work is valuable, regardless of"
                    " what results it was awarded, so don't worry too much about it")
-    message.append("And with that out of the way")
+    message.append("And with that out of the way...")
     message.append("*drumroll please*")
     for category in results:
         total = results[category][0]

--- a/http_server.py
+++ b/http_server.py
@@ -9,7 +9,7 @@ import compo
 import keys
 import bot
 
-config: dict = None
+config = None
 
 # TODO: replace [VUE-URL] ASAP?
 vote_template = open("templates/vote.html", "r").read()
@@ -362,7 +362,7 @@ async def allowed_hosts_handler(request: web_request.Request) -> web.Response:
 
 
 # Helpers
-def get_week_viewer(which_week: bool, only_valid: bool) -> str:
+def get_week_viewer(which_week: bool, only_valid: bool) -> dict:
     """
     Massages week data into the format that will be output as JSON.
     """


### PR DESCRIPTION
added warning to myresults, split some strings just above 80 chars, only allow myresults when voting isn't open, remove variable typing (not available on py 3.5 I think), correct function return type, shorten context.channel.send to context.send 